### PR TITLE
fix: align dashboard card content consistently irrespective of text size

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,9 +39,14 @@ export default function Home() {
         <div className="px-4 pb-6 pt-10 md:px-6 md:pb-20">
           <div className="grid grid-cols-[repeat(auto-fill,_minmax(350px,_1fr))] gap-6 md:gap-6">
             {resources.map((resource) => (
-              <Card key={resource.link} className="flex flex-col gap-y-6 bg-neutral-0 p-6 shadow-neutral-md">
+              <Card
+                key={resource.link}
+                className="flex flex-col justify-between gap-y-6 bg-neutral-0 p-6 shadow-neutral-md"
+              >
                 <Heading size="h2">{resource.name}</Heading>
-                <p className="text-neutral-500">{resource.description}</p>
+                <div className="flex grow flex-col justify-start">
+                  <p className="text-neutral-500">{resource.description}</p>
+                </div>
                 <span className="flex">
                   <Button
                     href={resource.link}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3542d2e2-dc05-4999-8c45-366f6d285752)
