### PR TITLE
coalesce toBlock and added min epoch time

### DIFF
--- a/pages/api/v1/votes/gaugeVotes.ts
+++ b/pages/api/v1/votes/gaugeVotes.ts
@@ -35,7 +35,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
 
       if (!toBlock || isNaN(Number(toBlock))) {
-        toBlock = "latest";
+        toBlock = "0";
       }
 
       // set optional fields


### PR DESCRIPTION
Fixed two issues:

1. Querying `epoch times` before genesis block or contracts deployment will return an error
2. toBlock bug that if not specified will crash is now fixed